### PR TITLE
Docs and enhancements for DevContainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
+ARG VARIANT=20-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# Install MongoDB command line tools - though mongo-database-tools not available on arm64
+ARG MONGO_TOOLS_VERSION=7.0
+RUN . /etc/os-release \
+  && curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_TOOLS_VERSION}.asc" | gpg --dearmor > /usr/share/keyrings/mongodb-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] http://repo.mongodb.org/apt/debian ${VERSION_CODENAME}/mongodb-org/${MONGO_TOOLS_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_TOOLS_VERSION}.list \
+  && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get install -y mongodb-mongosh \
+  && if [ "$(dpkg --print-architecture)" = "amd64" ]; then apt-get install -y mongodb-database-tools; fi \
+  && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,36 +1,30 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
-	"name": "Node.js & TypeScript",
+	"name": "Node.js & TypeScript & MongoDB",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:20",
+	"dockerComposeFile": "docker-compose.yml",
 	// Features to add to the dev container. More info: https://containers.dev/features.
+	"service": "app",
+	"workspaceFolder": "/workspace",
 	"features": {
-		"ghcr.io/devcontainers-contrib/features/gh-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
-		// 3000,
-		// 4000,
-		// 27017
+		3000,
+		27017
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "yarn install",
+	"postCreateCommand": "yarn install && yarn build",
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"esbenp.prettier-vscode"
+				"esbenp.prettier-vscode",
+				"mongodb.mongodb-vscode"
 			]
 		}
-	},
-	// "runArgs": [
-	// 	"--add-host=host.docker.internal:host-gateway"
-	// ],
-	// "remoteEnv": {
-		// "MONGODB_URI": "mongodb://host.docker.internal:27017"
-	// }
-	// Configure tool-specific properties.
-	// "customizations": {},
+	}
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  app:
+    env_file: docker.env
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Update 'VARIANT' to pick an LTS version of Node.js: 18, 16, 14.
+        # Append -bullseye or -buster to pin to an OS version.
+        # Use -bullseye variants on local arm64/Apple Silicon.
+        VARIANT: 20-bullseye
+    volumes:
+      - ..:/workspace:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+    # Uncomment the next line to use a non-root user for all processes.
+    # user: node
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: mongo:7
+    restart: unless-stopped
+    volumes:
+      - mongodb-data:/data/db
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+      MONGO_INITDB_DATABASE: bsky
+    # Add "forwardPorts": ["27017"] to **devcontainer.json** to forward MongoDB locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  mongodb-data:

--- a/.devcontainer/docker.env.example
+++ b/.devcontainer/docker.env.example
@@ -1,0 +1,35 @@
+# Whichever port you want to run this on
+FEEDGEN_PORT=3000
+
+# Change this to use a different bind address - probably 0.0.0.0 for prod
+FEEDGEN_LISTENHOST="0.0.0.0"
+
+# The mongodb connection string
+FEEDGEN_MONGODB_CONNECTION_STRING="mongodb://root:example@db:27017"
+
+# Don't change unless you're working in a different environment than the primary Bluesky network
+FEEDGEN_SUBSCRIPTION_ENDPOINT="wss://bsky.network"
+
+
+# Set this to the hostname that you intend to run the service at
+FEEDGEN_HOSTNAME="example.com"
+
+# Set this to the DID of the account you'll use to publish the feed
+# You can find your accounts DID by going to
+# https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle=${YOUR_HANDLE}
+FEEDGEN_PUBLISHER_DID="did:plc:abcde...."
+
+# Only use this if you want a service did different from did:web
+# FEEDGEN_SERVICE_DID="did:plc:abcde..."
+
+# Should be an app password
+FEEDGEN_PASSWORD="..."
+
+# Your handle - xyz.bsky.social e.g.
+FEEDGEN_HANDLE="..."
+
+# Delay between reconnect attempts to the firehose subscription endpoint (in milliseconds)
+FEEDGEN_SUBSCRIPTION_RECONNECT_DELAY=3000
+
+# The refresh timer. Algorithms have periodicTask() called this often.
+FEEDGEN_TASK_INTEVAL_MINS=15

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dist
 scripts/publishExternal.ts
 scripts/publishWords.ts
 images/external.jpg
+.devcontainer/docker.env

--- a/README.md
+++ b/README.md
@@ -24,17 +24,81 @@ Shows the user all NSFW videos from people they follow. This is a Video Feed, me
 
 Feed at https://bsky.app/profile/did:plc:bfuck3vwwacatltdmnilloym/feed/mutuals-ad-vid
 
-
 # Usage
 
 I run this with Digital Ocean App Platform, with their MongoDB as an attached service. Instructions for setting this up can be found in the above guide.
 
-To run a test feed locally I modified Bossett's original .devcontainer file to activate docker's internal host gateway and set up a connection to a local MongoDB instance by exposing more ports. Uncomment lines 26-31 to do this. I use [ngrok](https://ngrok.com/) to create a tunnel between my local docker instance's exposed IP and a hosted domain for feed publishing. 
+# Docker and Ngrok Testing
+
+For development and testing purposes, there is a docker-compose setup using Visual Studio Codes DevContainers. Start by using ngrok to create a temporary endpoint, add that to the `docker.env` file that references that endpoint as well as adding in your various configuration to publish the feed.
+
+An example:
+
+```Shell
+$ ngrok http http://localhost:3000
+ngrok                                                        (Ctrl+C to quit)
+�  Using ngrok for OSS? Request a community license: https://ngrok.com/r/oss
+Session Status                online
+Account                       John Doe (Plan: Basic)
+Version                       3.23.3
+Region                        Europe (eu)
+Latency                       24ms
+Web Interface                 http://127.0.0.1:4040
+Forwarding                    https://xyz.ngrok-free -> http://localhost:3000
+Connections                   ttl     opn     rt1     rt5     p50       p90
+                              19      0       0.00    0.00    5.15      5.29
+```
+
+Then, test these local and forwarded URLs to make sure the server is running correctly:
+
+- <http://localhost:3000/.well-known/did.json>
+- <https://xyz.ngrok-free.app/.well-known/did.json> (update "xyz." with the generated ngrok subdomain)
+
+```Shell
+$ curl http://localhost:3000/.well-known/did.json
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1"
+  ],
+  "id": "did:web:xyz.ngrok-free.app",
+  "service": [
+    {
+      "id": "#bsky_fg",
+      "type": "BskyFeedGenerator",
+      "serviceEndpoint": "https://xyz.ngrok-free.app"
+    }
+  ]
+}
+$ curl https://xyz.ngrok-free.app/.well-known/did.json | jq
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100   177  100   177    0     0    621      0 --:--:-- --:--:-- --:--:--   618
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1"
+  ],
+  "id": "did:web:xyz.ngrok-free.app",
+  "service": [
+    {
+      "id": "#bsky_fg",
+      "type": "BskyFeedGenerator",
+      "serviceEndpoint": "https://xyz.ngrok-free.app"
+    }
+  ]
+}
+```
+
+From there you can publish to BSky with the yarn commands, but all database requests will be sent to your local MongoDB instance.
+
+And since we have the MongoDB extension installed in our dev instance, we can easily connect and see that the posts are being added to our database:
+
+![Image](https://github.com/user-attachments/assets/d2120d4b-484b-4b0d-8e34-e72769cb7114)
+
+Remember to unpublish afterwards!
 
 ## Database
 
 The DB could feasibly be swapped out for any other, and there are lots of changes that could make it more efficient. However, if you're new I recommend using the provided dbClient.
-
 
 ## Adding Feeds
 


### PR DESCRIPTION
* Adds grok instructions
* Examples in docs
* Uses docker-compose to build mongodb

This is your repo so I dont wanna force any new workflows you dont wanna use, but I think for the MongoDB usecase you mention, this seems to be a cleaner way (at least in my testing)